### PR TITLE
Ether delayed gas check

### DIFF
--- a/src/GWallet.Backend/Account.fs
+++ b/src/GWallet.Backend/Account.fs
@@ -248,7 +248,11 @@ module Account =
             txId
             amountTransferredPlusFeeIfCurrencyFeeMatches
             fee.FeeValue
-    
+        match fee with
+        | :? Ether.TransactionMetadata as etherTxMetadata ->
+            Caching.Instance.StoreUnconfirmedTransaction fee.Currency txId etherTxMetadata.Fee.GasLimit
+        | _ -> ()
+
     // FIXME: broadcasting shouldn't just get N consistent replies from FaultTolerantClient,
     // but send it to as many as possible, otherwise it could happen that some server doesn't
     // broadcast it even if you sent it

--- a/src/GWallet.Backend/Account.fs
+++ b/src/GWallet.Backend/Account.fs
@@ -248,31 +248,16 @@ module Account =
             txId
             amountTransferredPlusFeeIfCurrencyFeeMatches
             fee.FeeValue
-
-    // FIXME: if out of gas, miner fee is still spent, we should inspect GasUsed and use it for the call to
-    //        SaveOutgoingTransactionInCache
-    let private CheckIfOutOfGas (transactionMetadata: IBlockchainFeeInfo) (txHash: string)
-                       : Async<unit> =
-        async {
-            match transactionMetadata with
-            | :? Ether.TransactionMetadata as etherTxMetadata ->
-                try
-                    let! outOfGas = Ether.Server.IsOutOfGas transactionMetadata.Currency txHash etherTxMetadata.Fee.GasLimit
-                    if outOfGas then
-                        return failwith <| SPrintF1 "Transaction ran out of gas: %s" txHash
-                with
-                | ex ->
-                    return raise <| Exception(SPrintF1 "An issue occurred while trying to check if the following transaction ran out of gas: %s" txHash, ex)
-            | _ ->
-                ()
-        }
-
+    
     // FIXME: broadcasting shouldn't just get N consistent replies from FaultTolerantClient,
     // but send it to as many as possible, otherwise it could happen that some server doesn't
     // broadcast it even if you sent it
     let BroadcastTransaction (trans: SignedTransaction<_>) (ignoreHigherMinerFeeThanAmount: bool): Async<Uri> =
         async {
             let currency = trans.TransactionInfo.Proposal.Amount.Currency
+
+            if currency.IsEtherBased() then
+                do! Ether.Server.CheckIfAddressIsAValidPaymentDestination Currency.ETH trans.TransactionInfo.Proposal.DestinationAddress
 
             let! txId =
                 if currency.IsEtherBased() then
@@ -281,8 +266,6 @@ module Account =
                     UtxoCoin.Account.BroadcastTransaction currency trans ignoreHigherMinerFeeThanAmount
                 else
                     failwith <| SPrintF1 "Unknown currency %A" currency
-
-            do! CheckIfOutOfGas trans.TransactionInfo.Metadata txId
 
             SaveOutgoingTransactionInCache trans.TransactionInfo.Proposal trans.TransactionInfo.Metadata txId
 
@@ -441,6 +424,9 @@ module Account =
         async {
             do! ValidateAddress currency destination
 
+            if currency.IsEtherBased() then
+                do! Ether.Server.CheckIfAddressIsAValidPaymentDestination Currency.ETH destination
+
             let! txId =
                 match txMetadata with
                 | :? UtxoCoin.TransactionMetadata as btcTxMetadata ->
@@ -459,8 +445,6 @@ module Account =
                     Ether.Account.SendPayment account etherTxMetadata destination amount password ignoreHigherMinerFeeThanAmount
                 | _ ->
                     failwith "Unknown tx metadata type"
-
-            do! CheckIfOutOfGas txMetadata txId
 
             let transactionProposal =
                 {

--- a/src/GWallet.Backend/Caching.fs
+++ b/src/GWallet.Backend/Caching.fs
@@ -14,6 +14,7 @@ type CachedNetworkData =
         UsdPrice: Map<Currency,CachedValue<decimal>>;
         Balances: Map<Currency,Map<PublicAddress,CachedValue<decimal>>>;
         OutgoingTransactions: Map<Currency,Map<PublicAddress,Map<string,CachedValue<decimal>>>>;
+        UnconfirmedTransactions: Map<Currency,list<string * int64>>
     }
     member self.GetLeastOldDate() =
         let allDates =
@@ -35,6 +36,7 @@ type CachedNetworkData =
             UsdPrice = Map.empty
             Balances = Map.empty
             OutgoingTransactions = Map.empty
+            UnconfirmedTransactions = Map.empty
         }
 
     static member FromDietCache (dietCache: DietCache): CachedNetworkData =
@@ -52,7 +54,8 @@ type CachedNetworkData =
                             yield (Currency.Parse currencyStr),Map.empty.Add(address,(balance,now))
             } |> Map.ofSeq
         { UsdPrice = fiatPrices; Balances = balances
-          OutgoingTransactions = Map.empty; }
+          OutgoingTransactions = Map.empty;
+          UnconfirmedTransactions = Map.empty }
 
     member self.ToDietCache(readOnlyAccounts: seq<ReadOnlyAccount>) =
         let rec extractAddressesFromAccounts (acc: Map<PublicAddress,List<DietCurrency>>) (accounts: List<IAccount>)
@@ -646,5 +649,35 @@ module Caching =
 
         member __.FirstRun
             with get() = firstRun
+
+        member self.StoreUnconfirmedTransaction (currency: Currency) (txHash: string) (gasLimit: int64) =
+            lock cacheFiles.CachedNetworkData (fun _ ->
+                let newTransactions =
+                    match sessionCachedNetworkData.UnconfirmedTransactions |> Map.tryFind currency with
+                    | Some transactionsForCurrency -> (txHash, gasLimit) :: transactionsForCurrency
+                    | None -> List.singleton (txHash, gasLimit)
+                let newCachedData = 
+                    { sessionCachedNetworkData with
+                        UnconfirmedTransactions = 
+                            sessionCachedNetworkData.UnconfirmedTransactions
+                            |> Map.add currency newTransactions }
+                SaveNetworkDataToDisk newCachedData
+            )
+
+        member self.RemoveUnconfirmedTransaction (currency: Currency) (txHash: string) =
+            lock cacheFiles.CachedNetworkData (fun _ ->
+                match sessionCachedNetworkData.UnconfirmedTransactions |> Map.tryFind currency with
+                | Some transactionsForCurrency ->
+                    let newTransactionForCurrency = 
+                        transactionsForCurrency 
+                        |> List.filter (fun (hash, _) -> hash <> txHash)
+                    let newCachedData = 
+                        { sessionCachedNetworkData with
+                            UnconfirmedTransactions = 
+                                sessionCachedNetworkData.UnconfirmedTransactions
+                                |> Map.add currency newTransactionForCurrency }
+                    SaveNetworkDataToDisk newCachedData
+                | None -> ()
+            )
 
     let Instance = MainCache (None, TimeSpan.FromDays 1.0)

--- a/src/GWallet.Frontend.Console/UserInteraction.fs
+++ b/src/GWallet.Frontend.Console/UserInteraction.fs
@@ -352,6 +352,24 @@ module UserInteraction =
                     // All balances are fetched and their currency names printed, put a dot at the end of "Retrieving balances... " line.
                     Console.Write '.'
 
+                    let unconfirmedStatuses = ResizeArray<string>()
+                    for account in accounts do
+                        if account.Currency.IsEtherBased() then
+                            let cache = Caching.Instance.GetLastCachedData()
+                            match cache.UnconfirmedTransactions |> Map.tryFind account.Currency with
+                            | Some unconfirmedTransactions ->
+                                for txHash, gasSpent in unconfirmedTransactions do
+                                    try
+                                        let! isOutOfGas = Ether.Server.IsOutOfGas account.Currency txHash gasSpent
+                                        if isOutOfGas then
+                                            unconfirmedStatuses.Add(sprintf "Transaction ran out of gas: 0x%s" txHash)
+                                        else
+                                            Caching.Instance.RemoveUnconfirmedTransaction account.Currency txHash
+                                    with
+                                    | :? TimeoutException ->
+                                        unconfirmedStatuses.Add(sprintf "Timed out when checking transaction 0x%s" txHash)
+                            | None -> ()
+
                     let maybeTotalInUsd, totals = displayTotalAndSumFiatBalance currencyTotals
                     return
                         seq {
@@ -362,6 +380,7 @@ module UserInteraction =
                                     seq {
                                         yield! statuses
                                         yield! totals
+                                        yield! unconfirmedStatuses
                                         yield String.Empty // this ends up being simply an Environment.NewLine
                                         yield sprintf "Total estimated value in USD: %s"
                                                       (Formatting.DecimalAmountRounding CurrencyType.Fiat totalInUsd)


### PR DESCRIPTION
After sending Ethereum transaction, don't poll the server to
check if transaction is out of gas.

Instead, check if recipient is a contract address.

And when showing balances check check for confirmation of unconfirmed Ethereum txs.