### PR TITLE
Backend: fix servers.json URL for BTC

### DIFF
--- a/src/GWallet.Backend/UtxoCoin/ElectrumServer.fs
+++ b/src/GWallet.Backend/UtxoCoin/ElectrumServer.fs
@@ -134,7 +134,7 @@ module ElectrumServerSeedList =
 
         let urlToElectrumJsonFile =
             match currency with
-            | Currency.BTC -> "https://raw.githubusercontent.com/spesmilo/electrum/master/electrum/servers.json"
+            | Currency.BTC -> "https://raw.githubusercontent.com/spesmilo/electrum/master/electrum/chains/servers.json"
             | Currency.LTC -> "https://raw.githubusercontent.com/pooler/electrum-ltc/master/electrum_ltc/servers.json"
             | _ -> failwith <| SPrintF1 "UTXO currency unknown to this algorithm: %A" currency
 


### PR DESCRIPTION
The servers.json file in spesmilo/electrum repository was moved in commit[1].

[1] https://github.com/spesmilo/electrum/commit/309b2a96afa3b8355e6f8f83ba7489e1bd8d36f1